### PR TITLE
Remove duplicate CTS tests from libcore cts packages.

### DIFF
--- a/core/tasks/cts.mk
+++ b/core/tasks/cts.mk
@@ -202,7 +202,16 @@ $(CTS_TESTCASES_OUT)/android.core.tests.libcore.package.org.xml: $(CTS_CORE_XMLS
 	$(hide) mkdir -p $(CTS_TESTCASES_OUT)
 	$(call generate-core-test-description,$(CTS_TESTCASES_OUT)/android.core.tests.libcore.package.org,\
 		cts/tests/core/libcore/org/AndroidManifest.xml,\
-		$(CORETESTS_INTERMEDIATES)/javalib.jar,org,\
+		$(CORETESTS_INTERMEDIATES)/javalib.jar,\
+		org.w3c.domts:\
+		org.apache.harmony.security.tests:\
+		org.apache.harmony.nio.tests:\
+		org.apache.harmony.crypto.tests:\
+		org.apache.harmony.regex.tests:\
+		org.apache.harmony.luni.tests:\
+		org.apache.harmony.tests.internal.net.www.protocol:\
+		org.apache.harmony.tests.javax.net:\
+		org.json,\
 		$(TARGET_ARCH),libcore/expectations)
 
 $(CTS_TESTCASES_OUT)/android.core.tests.libcore.package.libcore.xml: $(CTS_CORE_XMLS_DEPS)


### PR DESCRIPTION
The catch all "org" package was catching several thousand
org.apache.harmony.tests.* tests that are already covered by
other packages. Replace the catch-all org.* with specific prefixes.

Needs additional support in CollectAllTests to handle multiple
prefixes. This is implemented in the companion change.

bug: 20862863

(cherry picked from commit cf7fbcd03d9f13d1c2fe6e65f02247feadec136d)

Change-Id: I1d28f91cfca098ccdcd62e88bb486b433d9c29d8